### PR TITLE
Support for non-OpenAI models

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ fleet-context
 
 ### Limit libraries
 
-You can use the `-l` or `--libraries` followed by a list of libraries to limit your session to a certain number of libraries. Defaults to all.
+You can use the `-l` or `--libraries` followed by a list of libraries to limit your session to a certain number of libraries. Defaults to all. View a list of all supported libraries on [our website](https://fleet.so/context).
 
 ```shell
 context -l langchain pydantic openai

--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ pip install -e .
 context
 ```
 
+If you have an existing package that already uses they keyword `context`, you can also activate Fleet Context by running:
+```shell
+fleet-context
+```
+
 <br>
 
 ### Limit libraries

--- a/README.md
+++ b/README.md
@@ -70,6 +70,23 @@ context -m gpt-4-1106-preview
 
 <br>
 
+### Use non-OpenAI models
+
+You can use Claude, CodeLlama, Mistral, and many other models by
+1. creating an API key on [OpenRouter](https://openrouter.ai) (visit the [Keys](https://openrouter.ai/keys) page after signing up)
+2. setting `OPENROUTER_API_KEY` as an environment variable
+3. specifying your model using the company prefix, e.g.:
+
+```shell
+context -m phind/phind-codellama-34b
+```
+
+OpenAI models work this way as well; just use e.g. `openai/gpt-4-32k`. Other model options are available [here](https://openrouter.ai/models).
+
+Optionally, you can attribute your inference token usage to your app or website by setting `OPENROUTER_APP_URL` and `OPENROUTER_APP_TITLE`. Your app will show on the homepage of https://openrouter.ai if ranked.
+
+<br>
+
 ### Using local models
 
 Local model support is powered by [LM Studio](https://lmstudio.ai). To use local models, you can use `--local` or `-n`:

--- a/cli.py
+++ b/cli.py
@@ -83,16 +83,17 @@ def main():
         filters["library_name"] = args.libraries
 
     # Get the OpenAI API key, if not found
-    if not os.environ.get("OPENAI_API_KEY"):
+    api_key = os.environ.get("OPENAI_API_KEY") or os.environ.get("OPENROUTER_API_KEY")
+    if not api_key:
         print_markdown(
             """---
-        !!!**OpenAI API key not found.**
+        !!!**OpenAI/OpenRouter API key not found.**
 
         Please provide a key to proceed.
         ---
         """
         )
-        api_key = getpass("OpenAI API key: ")
+        api_key = getpass("API key: ")
         openai.api_key = api_key
 
         print_markdown(
@@ -100,11 +101,13 @@ def main():
         ---
 
         **Tip**: To save this key for later, run `export OPENAI_API_KEY=<your key>` on mac/linux or `setx OPENAI_API_KEY <your key>` on windows.
+        
+        For non-OpenAI models, you should set `OPENROUTER_API_KEY`, and optionally `OPENROUTER_APP_URL` and `OPENROUTER_APP_TITLE`.
 
         ---"""
         )
     else:
-        openai.api_key = os.environ.get("OPENAI_API_KEY")
+        openai.api_key = api_key
 
     if model == "gpt-4-1106-preview":
         print_markdown(

--- a/utils/ai.py
+++ b/utils/ai.py
@@ -151,7 +151,7 @@ def get_openai_chat_response(messages, model="gpt-4-1106-preview"):
     str: The streamed OpenAI chat response.
     """
     try:
-        response = openai.ChatCompletion.create(
+        response = createCompletion(
             model=model, messages=messages, temperature=0.2, stream=True
         )
 
@@ -166,3 +166,25 @@ def get_openai_chat_response(messages, model="gpt-4-1106-preview"):
     except Exception as error:
         print("Streaming Error:", error)
         raise Exception("Internal Server Error")
+
+def createCompletion(
+    model,
+    **kwargs
+):
+    if "/" in model:
+        if not os.environ.get('OPENROUTER_API_KEY'):
+            raise Exception(f"For non-OpenAI models, like {model}, set your OPENROUTER_API_KEY.")
+        return openai.ChatCompletion.create(
+            api_base="https://openrouter.ai/api/v1",
+            headers={
+                "HTTP-Referer": os.environ.get('OPENROUTER_APP_URL', "https://fleet.so/context"),
+                "X-Title": os.environ.get('OPENROUTER_APP_TITLE', "Fleet Context")
+            },
+            model=model,
+            **kwargs
+        )
+    else:
+        return openai.Completion.create(
+            model=model,
+            **kwargs
+        )


### PR DESCRIPTION
Love Context - fantastic idea!

This is just a suggestion PR in case you want to add support for hosted, non-OpenAI models (https://openrouter.ai), including CodeLlama. It also enables free (er, 100% discounted) inference, if you want to use Mistral 7B or Zephyr 7B.

Making this PR in part so I can use context with my openrouter models, and in part to hear your feedback