### PR TITLE
Fix #2: UnicodeDecodeError: 'charmap' codec

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fleet-context"
-version = "1.0.13"
+version = "1.0.15"
 description = "A chat interface over up-to-date Python library documentation."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,9 @@ from setuptools import setup, find_packages
 
 setup(
     name="fleet-context",
-    version="1.0.13",
+    version="1.0.15",
     description="A chat interface over up-to-date Python library documentation.",
-    long_description=open("README.md").read(),
+    long_description=open("README.md", "r", encoding="utf8").read(),
     long_description_content_type="text/markdown",
     author="Fleet AI",
     author_email="team@usefleet.ai",

--- a/utils/ai.py
+++ b/utils/ai.py
@@ -156,7 +156,6 @@ def get_openai_chat_response(messages, model="gpt-4-1106-preview"):
         )
 
         for chunk in response:
-            print(chunk.choices[0].delta)
             current_context = chunk.choices[0].delta.content
             yield current_context
 


### PR DESCRIPTION
Issue #2:
- Issue was caused during the setup process when reading README.txt. In Windows, the default encoding is different, but that readme file is most likely encoded in UTF8.

Fix:
- Added encoding="utf8" to read from README.txt
- Removed print statement that was there from debugging