### PR TITLE
Fix typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
     <br>
     <b>A CLI tool over the top 1218 Python libraries.</b>
     <br>
-    <span>Used for library q/a & code generation with all avaliable OpenAI models</span>
+    <span>Used for library q/a & code generation with all available OpenAI models</span>
     <br>
     <br>
     <a href="https://alpha.usefleet.ai/context">Website</a>

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ pip install -e .
 context
 ```
 
-If you have an existing package that already uses they keyword `context`, you can also activate Fleet Context by running:
+If you have an existing package that already uses the keyword `context`, you can also activate Fleet Context by running:
 
 ```shell
 fleet-context


### PR DESCRIPTION
Fixed typos:

- `avaliable` →  `available` in `README.md`.
- `they keyword` → `the keyword` in `README.md`